### PR TITLE
Remove Global CSS Import

### DIFF
--- a/packages/slate-table/src/controls/ControlledRangeDisableAcross.tsx
+++ b/packages/slate-table/src/controls/ControlledRangeDisableAcross.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
 import Slider, { Range } from 'rc-slider';
-import 'rc-slider/assets/index.css';
 
 const ControlledRangeDisableAcross = ({ initialValue = [], onChange }) => {
   const [value, setValue] = useState(initialValue);


### PR DESCRIPTION
## Problem
This library does not work on Next JS.

## Reason
Nextjs does not allow Global CSS Import, hence the import ```import 'rc-slider/assets/index.css';``` causes it not to work on Next.

## Solution 
Remove this line, and ask the dev to add it to their project themselves.